### PR TITLE
Make sure ReactContext is initialized before calling getJSModule()

### DIFF
--- a/android/src/main/java/com/jadsonlourenco/RNShakeEvent/RNShakeEventModule.java
+++ b/android/src/main/java/com/jadsonlourenco/RNShakeEvent/RNShakeEventModule.java
@@ -35,6 +35,8 @@ public class RNShakeEventModule extends ReactContextBaseJavaModule implements Sh
     private void sendEvent(ReactContext reactContext,
                            String eventName,
                            @Nullable WritableMap params) {
-        reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
+        if (reactContext.hasActiveCatalystInstance()) {
+            reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class).emit(eventName, params);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/thunkable/react-native-shake-event/issues/3